### PR TITLE
Fix Incorrect OS Checking

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -51,7 +51,7 @@ def Checker():
     print("\033[91m INVALID |",nitro + '\033[0m')
   return
 
-if "win" in sys.platform:
+if sys.platform == "win":
     os.system("cls")
 elif "linux" in sys.platform or "darwin" in sys.platform:
     os.system("clear")
@@ -103,7 +103,7 @@ def Start():
       count += 1
 
       title = f"-- DISCORD NITRO BRUTEFORCER -- Threads started: {count} Currently Active Threads: {active_count()}"
-      if "win" in sys.platform:
+      if sys.platform == "win":
           os.system("title " + title)
       elif "linux" in sys.platform or "darwin" in sys.platform:
           os.system("echo -ne '\033]0;" + title + "\007'")

--- a/checker.py
+++ b/checker.py
@@ -51,9 +51,9 @@ def Checker():
     print("\033[91m INVALID |",nitro + '\033[0m')
   return
 
-if sys.platform == "win":
+if "linux" in sys.platform or "darwin" in sys.platform:
     os.system("cls")
-elif "linux" in sys.platform or "darwin" in sys.platform:
+elif "win" in sys.platform:
     os.system("clear")
 	
 print("""	
@@ -103,9 +103,9 @@ def Start():
       count += 1
 
       title = f"-- DISCORD NITRO BRUTEFORCER -- Threads started: {count} Currently Active Threads: {active_count()}"
-      if sys.platform == "win":
-          os.system("title " + title)
-      elif "linux" in sys.platform or "darwin" in sys.platform:
+      if "linux" in sys.platform or "darwin" in sys.platform:
           os.system("echo -ne '\033]0;" + title + "\007'")
+      elif "win" in sys.platform:
+          os.system("title " + title)
 Start()
 


### PR DESCRIPTION
The line `if "win" in sys.platform:` will not work for MacOS because the string `"win"` is in the MacOS identifier `"darwin"`, so the program recognizes Mac systems as windows, making the incorrect system calls.

Fixed this by checking for MacOS and Linux before Windows, to ensure Darwin gets matched before Win.